### PR TITLE
Trigger cookie setting after cache clear

### DIFF
--- a/background.js
+++ b/background.js
@@ -168,14 +168,10 @@
       }
     }
 
-    if (actions.cookies) {
-      for (const cookie of actions.cookies) {
-        if (isChrome) {
-          setCookie(cookie.name, cookie.value, cookie.url);
-        } else {
-          allPromises.push(setCookie(cookie.name, cookie.value, cookie.url));
-        }
-      }
+    function setCookies() {
+      return actions.cookies.map(cookie =>
+        setCookie(cookie.name, cookie.value, cookie.url)
+      );
     }
 
     if (actions.clearCache) {
@@ -198,7 +194,7 @@
             serverBoundCertificates: true,
             serviceWorkers: true
           },
-          function() {}
+          setCookies
         );
       } else {
         allPromises.push(
@@ -225,6 +221,9 @@
         );
       }
     }
-    return Promise.all(allPromises);
+
+    if (!isChrome) {
+      return Promise.all(allPromises).then(() => Promise.all(setCookies()));
+    }
   });
 })();


### PR DESCRIPTION
Address Issue https://github.com/sitespeedio/browsertime-extension/issues/12 (params.clear overrides params.cookies (deletes cookies))

**Chrome**: Pass setCookies as [`browsingData.remove` callback](https://developer.chrome.com/extensions/browsingData#method-remove)
**Firefox**: Trigger setCookies after [`browsingData.remove` Promises have been resolved](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/set#Return_value)